### PR TITLE
Add nested bucketing support

### DIFF
--- a/boltons/iterutils.py
+++ b/boltons/iterutils.py
@@ -730,7 +730,13 @@ def bucketize(src, key=bool, value_transform=None, key_filter=None):
         src = zip(key, src)
 
     if isinstance(key, str):
-        def key_func(x): return getattr(x, key, x)
+        def key_func(x):
+            if hasattr(x, key):
+                return getattr(x, key)
+            try:
+                return x[key]
+            except Exception:
+                return x
     elif callable(key):
         key_func = key
     elif isinstance(key, list):
@@ -752,6 +758,33 @@ def bucketize(src, key=bool, value_transform=None, key_filter=None):
         if key_filter is None or key_filter(key_of_val):
             ret.setdefault(key_of_val, []).append(value_transform(val))
     return ret
+
+
+def nested_bucketize(src, *keys, value_transform=None):
+    """Recursively bucketize ``src`` by each of ``keys``.
+
+    Works like :func:`bucketize`, but nests dictionaries according to
+    successive keys. ``value_transform`` is applied to values in the
+    innermost buckets.
+
+    >>> items = [{'color': 'red', 'shape': 'triangle'},
+    ...          {'color': 'blue', 'shape': 'square'},
+    ...          {'color': 'red', 'shape': 'circle'}]
+    >>> nested_bucketize(items, 'color', 'shape')
+    {'red': {'triangle': [items[0]], 'circle': [items[2]]},
+     'blue': {'square': [items[1]]}}
+    """
+
+    if not keys:
+        raise TypeError('expected at least one key')
+    if len(keys) == 1:
+        return bucketize(src, keys[0], value_transform=value_transform)
+
+    first = bucketize(src, keys[0])
+    for k, vals in first.items():
+        first[k] = nested_bucketize(vals, *keys[1:],
+                                   value_transform=value_transform)
+    return first
 
 
 def partition(src, key=bool):

--- a/docs/iterutils.rst
+++ b/docs/iterutils.rst
@@ -81,6 +81,18 @@ These functions operate on iterables, dividing into groups based on a
 given condition.
 
 .. autofunction:: bucketize
+.. autofunction:: nested_bucketize
+
+Example of nested bucketing::
+
+    >>> data = [
+    ...     {'color': 'red', 'shape': 'triangle'},
+    ...     {'color': 'red', 'shape': 'circle'},
+    ...     {'color': 'blue', 'shape': 'square'}]
+    >>> nested_bucketize(data, 'color', 'shape')
+    {'red': {'triangle': [{'color': 'red', 'shape': 'triangle'}],
+             'circle': [{'color': 'red', 'shape': 'circle'}]},
+     'blue': {'square': [{'color': 'blue', 'shape': 'square'}]}}
 .. autofunction:: partition
 
 Sorting

--- a/tests/test_iterutils.py
+++ b/tests/test_iterutils.py
@@ -598,3 +598,42 @@ def test_windowed_filled():
 
     assert list(windowed_iter(range(4), 3)) == [(0, 1, 2), (1, 2, 3)]
     assert list(windowed_iter(range(4), 3, fill=None)) == [(0, 1, 2), (1, 2, 3), (2, 3, None), (3, None, None)]
+
+
+def test_nested_bucketize_basic():
+    from boltons.iterutils import nested_bucketize
+
+    items = [
+        {'color': 'red', 'shape': 'triangle'},
+        {'color': 'blue', 'shape': 'square'},
+        {'color': 'red', 'shape': 'circle'},
+    ]
+
+    result = nested_bucketize(items, 'color', 'shape')
+    assert result == {
+        'red': {
+            'triangle': [items[0]],
+            'circle': [items[2]],
+        },
+        'blue': {'square': [items[1]]},
+    }
+
+
+def test_nested_bucketize_value_transform():
+    from boltons.iterutils import nested_bucketize
+
+    items = [
+        {'color': 'red', 'shape': 'triangle', 'id': 1},
+        {'color': 'red', 'shape': 'triangle', 'id': 2},
+    ]
+
+    res = nested_bucketize(items, 'color', 'shape', value_transform=lambda x: x['id'])
+    assert res == {'red': {'triangle': [1, 2]}}
+
+
+def test_bucketize_mapping_key():
+    from boltons.iterutils import bucketize
+
+    data = [{'a': 1}, {'a': 2}]
+
+    assert bucketize(data, 'a') == {1: [{'a': 1}], 2: [{'a': 2}]}


### PR DESCRIPTION
## Summary
- introduce `nested_bucketize` for recursive bucketing
- improve `bucketize` string key handling for mappings
- document and test new helper

## Testing
- `pytest tests/test_iterutils.py::test_nested_bucketize_basic tests/test_iterutils.py::test_nested_bucketize_value_transform tests/test_iterutils.py::test_bucketize_mapping_key -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f7bff99488329afed6f6de87d21fb